### PR TITLE
Adding 'install to the local python folder' in install tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,15 @@
 .DS_Store
 .cache
 build
+aitom.egg-info
+dist
 ext
 .vscode
 aitom/tomominer/core/cython/core.cpp
 __pycache__
 data
+result
+tmp
 .ipynb_checkpoints
 *.so
 

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,2 @@
 python setup.py build_ext --inplace
+python setup.py install --user

--- a/doc/install.md
+++ b/doc/install.md
@@ -1,7 +1,7 @@
 # Build library
 ## Ubuntu
 
-1. install dependencies and build
+1. install dependencies, build ext_modules, and install to the system python folder
 ```bash
 sudo apt-get install -y build-essential    # optional step
 sudo apt-get install -y python python3-dev fftw3-dev libblas3 liblapack3 libarmadillo-dev


### PR DESCRIPTION
I found that the current tutorial about installing is not installed to the local python folder.
That means the users cannot successfully import in a location other than cloned `aitom` repository。