### PR TITLE
Update simulation demo and generate density map demo

### DIFF
--- a/doc/tutorials/000_general/demo_simulation.py
+++ b/doc/tutorials/000_general/demo_simulation.py
@@ -28,7 +28,7 @@ def simulation(num, SNR, missing_wedge_angle, MCs, dense_map_file):
             'ctf':{'pix_size':1.2, 'Dz':-2.0, 'voltage':300, 'Cs':2.7, 'sigma':0.4}}                                                                                                               
             op['model']['SNR'] = SNR
             op['model']['missing_wedge_angle'] = missing_wedge_angle                                                                                                                        
-            vb = TSRE.do_reconstruction(vrr, op, verbose=True)['vb']                                                                                                                                         
+            vb = TSRE.do_reconstruction(vrr, op, verbose=True)                                                                                                                                         
             subtomograms.append(vb)                                                                                                                                                                     
                                                                                                                                                                                                             
     return(subtomograms)                                                                                                                                                                                
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     b['5T2C_template'] = simulation(1, N.float('Inf'), 0, ['5T2C'], dense_map_file)[0]
     b['1KP8_template'] = simulation(1, N.float('Inf'), 0, ['1KP8'], dense_map_file)[0]
                                                                      
-    TIF.pickle.dump(b, 'aitom_demo_subtomograms.pickle')                                                                                      
+    TIF.pickle_dump(b, 'aitom_demo_subtomograms.pickle')                                                                                      
                                                                                                                                                                                                             
                                                                                                                                                                                                         
 

--- a/doc/tutorials/000_general/demo_simulation.py
+++ b/doc/tutorials/000_general/demo_simulation.py
@@ -2,7 +2,8 @@ import pickle, uuid, os, sys, gc, multiprocessing, itertools
 import numpy as N                                                                                                                                                                                           
 import tomominer.geometry.rotate as GR                                                                                                                                                                      
 import tomominer.geometry.ang_loc as AAL                                                                                                                                                                    
-import tomominer.simulation.reconstruction__eman2 as TSRE                                                                                                                                                   
+import tomominer.simulation.reconstruction__eman2 as TSRE
+# import tomominer.simulation.reconstruction__simple_convolution as TSRSC
 import tomominer.image.vol.util as TIVU                                                                                                                                                                     
 import tomominer.io.file as TIF                                                                                                                                                                             
 
@@ -27,7 +28,7 @@ def simulation(num, SNR, missing_wedge_angle, MCs, dense_map_file):
             'ctf':{'pix_size':1.2, 'Dz':-2.0, 'voltage':300, 'Cs':2.7, 'sigma':0.4}}                                                                                                               
             op['model']['SNR'] = SNR
             op['model']['missing_wedge_angle'] = missing_wedge_angle                                                                                                                        
-            vb = do_reconstruction(vrr, op, verbose=True)['vb']                                                                                                                                         
+            vb = TSRE.do_reconstruction(vrr, op, verbose=True)['vb']                                                                                                                                         
             subtomograms.append(vb)                                                                                                                                                                     
                                                                                                                                                                                                             
     return(subtomograms)                                                                                                                                                                                

--- a/doc/tutorials/002_generate_density_map.py
+++ b/doc/tutorials/002_generate_density_map.py
@@ -20,8 +20,8 @@ op = {'situs_pdb2vol_program':'/shared/opt/local/img/em/et/util/situs/Situs_2.7.
 
 # convert to density maps, save to situs_maps.pickle
 import aitom.structure.pdb.situs_pdb2vol__batch as TSPS
-TSPS.batch_processing(op)
-
+re = TSPS.batch_processing(op)
+with open(op['out_file'], 'wb') as f:   pickle.dump(re, f, protocol=-1)
 
 
 '''


### PR DESCRIPTION
1. cannot find 'tomominer.simulation.reconstruction__eman2' in 172 server but 'tomominer.simulation.reconstruction__simple_convolution' works. I just comment the package.
2. should be 'TSRE.do_reconstruction()'
3. 'TSPS.batch_processing(op)' only return the density map but need to save to the local disk